### PR TITLE
Remove BibTeX link

### DIFF
--- a/README.md
+++ b/README.md
@@ -2,8 +2,6 @@
 
 - CSL 官方仓库：https://github.com/citation-style-language/styles
 - GB/T 7714相关的csl以及Zotero使用技巧及教程：https://github.com/redleafnew/Chinese-STD-GB-T-7714-related-csl
-- GB/T 7714-2015 BibTeX Style：https://github.com/zepinglee/gbt7714-bibtex-style
-- A rework of the GB/T 7714—2015 style for CSL：https://github.com/zepinglee/gb-t-7714-csl-style
 - 中文国关及小部分综合社科期刊CSL: https://github.com/EdwardSaidZhou/CSL-Chinese-IR-CSSCI-Journals
 
 ## 这个仓库
@@ -31,7 +29,7 @@
 - 在 `preview.py` 中，（WORK IN PROGRESS）
 
   - 从 `csl/*.csl` 提取 `<info>` 内的信息，
- 
+
   - 向引文处理服务器请求获得其引文和书目样式预览，处理后以 yaml 格式一并写入 `docs/preview/{uuid.md}` 中的 `Front Matter`；
 
   - 将以上信息按 author-data、numeric 或 journal、thesis 等分类方式排序归类，分别写入 `{Category-type}/{Category-name}.md` 。


### PR DESCRIPTION
1. BibTeX style 跟 csl 无关。
2. https://github.com/zepinglee/gb-t-7714-csl-style 的内容已经整合到 https://github.com/redleafnew/Chinese-STD-GB-T-7714-related-csl 了。